### PR TITLE
Support publishing from Travis (Including OSX and Linux artifacts!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ script:
 
 stages:
   - name: test
-    if: tag IS NOT present # TODO REMOVE
-  - name: deploy
+  - name: publish
     if: tag IS present
 
 jobs:
@@ -31,15 +30,15 @@ jobs:
     - name: "Test on Windows"
       stage: test
       os: windows
-    - name: "Deploy from Linux"
-      stage: deploy
+    - name: "Publish from Linux"
+      stage: publish
       os: linux
       script: npm run publish
-    - name: "Deploy from OSX"
-      stage: deploy
+    - name: "Publish from OSX"
+      stage: publish
       os: osx
       script: npm run publish
-    - name: "Deploy from Windows"
-      stage: deploy
+    - name: "Publish from Windows"
+      stage: publish
       os: windows
       script: npm run publish

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
+const renameExecutable = (makeResult) => {
+  const artifactNameBase = `cucumber-forge-desktop-${makeResult.platform}-${makeResult.arch}-${makeResult.packageJSON.version}-Setup`;
+  const append = makeResult.platform === 'win32' ? '.exe' : '.dmg';
+  const currFile = makeResult.artifacts.filter(artifact => artifact.endsWith(append))[0];
+  const newFile = `${path.parse(currFile).dir}/${artifactNameBase}${append}`;
+  // eslint-disable-next-line no-param-reassign
+  makeResult.artifacts[makeResult.artifacts.indexOf(currFile)] = newFile;
+  return fs.renameSync(currFile, newFile);
+};
+
 module.exports = {
   packagerConfig: {
     icon: './src/resources/icons/logo',
@@ -47,16 +57,8 @@ module.exports = {
   hooks: {
     postMake: async (forgeConfig, makeResults) => {
       // Rename the windows and OSX executables for consistency
-      await makeResults.filter(result => result.platform === 'win32' || result.platform === 'darwin')
-        .forEach((makeResult) => {
-          const artifactNameBase = `cucumber-forge-desktop-${makeResult.platform}-${makeResult.arch}-${makeResult.packageJSON.version}-Setup`;
-          const append = makeResult.platform === 'win32' ? '.exe' : '.dmg';
-          const currFile = makeResult.artifacts.filter(artifact => artifact.endsWith(append))[0];
-          const newFile = `${path.parse(currFile).dir}/${artifactNameBase}${append}`;
-          // eslint-disable-next-line no-param-reassign
-          makeResult.artifacts[makeResult.artifacts.indexOf(currFile)] = newFile;
-          return fs.renameSync(currFile, newFile);
-        });
+      await makeResults.filter(result => ['win32', 'darwin'].includes(result.platform))
+        .forEach(renameExecutable);
       return makeResults;
     },
   },

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  packagerConfig: {
+    icon: './src/resources/icons/logo',
+    executableName: 'cucumber-forge',
+  },
+  makers: [
+    {
+      name: '@electron-forge/maker-squirrel',
+      config: {
+        title: 'Cucumber Forge',
+        name: 'cucumber_forge_desktop',
+        exe: 'cucumber-forge.exe',
+        setupIcon: './src/resources/icons/logo.ico',
+        loadingGif: './src/resources/loading.gif',
+        iconUrl: 'https://raw.githubusercontent.com/cerner/cucumber-forge-desktop/master/src/resources/icons/logo.ico',
+      },
+    },
+    {
+      name: '@electron-forge/maker-dmg',
+      config: {
+        name: 'Cucumber Forge',
+        icon: './src/resources/icons/logo.icns',
+      },
+    },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: [
+        'linux',
+      ],
+    },
+  ],
+  publishers: [
+    {
+      name: '@electron-forge/publisher-github',
+      config: {
+        repository: {
+          owner: 'cerner',
+          name: 'cucumber-forge-desktop',
+        },
+        draft: true,
+      },
+    },
+  ],
+  hooks: {
+    postMake: async (forgeConfig, makeResults) => {
+      // Rename the windows and OSX executables for consistency
+      await makeResults.filter(result => result.platform === 'win32' || result.platform === 'darwin')
+        .forEach((makeResult) => {
+          const artifactNameBase = `cucumber-forge-desktop-${makeResult.platform}-${makeResult.arch}-${makeResult.packageJSON.version}-Setup`;
+          const append = makeResult.platform === 'win32' ? '.exe' : '.dmg';
+          const currFile = makeResult.artifacts.filter(artifact => artifact.endsWith(append))[0];
+          const newFile = `${path.parse(currFile).dir}/${artifactNameBase}${append}`;
+          // eslint-disable-next-line no-param-reassign
+          makeResult.artifacts[makeResult.artifacts.indexOf(currFile)] = newFile;
+          return fs.renameSync(currFile, newFile);
+        });
+      return makeResults;
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-forge-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-forge-desktop",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cucumber-forge-desktop",
   "productName": "cucumber-forge-desktop",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Cucumber Forge Desktop Application",
   "main": "src/index.js",
   "scripts": {
@@ -26,53 +26,10 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "icon": "./src/resources/icons/logo",
-        "executableName": "cucumber-forge"
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "title": "Cucumber Forge",
-            "name": "cucumber_forge_desktop",
-            "exe": "cucumber-forge.exe",
-            "setupIcon": "./src/resources/icons/logo.ico",
-            "loadingGif": "./src/resources/loading.gif",
-            "iconUrl": "https://raw.githubusercontent.com/cerner/cucumber-forge-desktop/master/src/resources/icons/logo.ico"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-dmg",
-          "config": {
-            "name": "Cucumber Forge",
-            "icon": "./src/resources/icons/logo.icns"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "linux"
-          ]
-        }
-      ],
-      "publishers": [
-        {
-          "name": "@electron-forge/publisher-github",
-          "config": {
-            "repository": {
-              "owner": "jkuester",
-              "name": "cucumber-forge-desktop"
-            },
-            "draft": true
-          }
-        }
-      ]
-    }
+    "forge": "./forge.config.js"
   },
   "updater": {
-    "url": "https://raw.githubusercontent.com/jkuester/cucumber-forge-desktop/publish_from_travis/updates.json",
+    "url": "https://raw.githubusercontent.com/cerner/cucumber-forge-desktop/master/updates.json",
     "autoDownload": false
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cucumber-forge-desktop",
   "productName": "cucumber-forge-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cucumber Forge Desktop Application",
   "main": "src/index.js",
   "scripts": {

--- a/updates.json
+++ b/updates.json
@@ -1,19 +1,8 @@
 {
   "win32-x64-prod": {
     "readme": "Second Release",
-    "update": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1",
-    "install": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1/cucumber-forge-desktop-0.2.1.Setup.exe",
-    "version": "0.2.1"
-  },
-  "darwin-x64-prod": {
-    "readme": "Second Release",
-    "update": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1/release.json",
-    "install": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1/Cucumber.Forge.dmg",
-    "version": "0.2.1"
-  },
-  "linux-x64-prod": {
-    "update": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1",
-    "install": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.1/cucumber-forge.zip",
-    "version": "0.2.1"
+    "update": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.0",
+    "install": "https://github.com/jkuester/cucumber-forge-desktop/releases/download/v0.2.0/cucumber-forge-desktop-0.2.0.Setup.exe",
+    "version": "0.2.0"
   }
 }


### PR DESCRIPTION
Add support for making and publishing artifacts from Travis to a draft GitHub release when a tag is pushed for cucumber-forge-desktop.  This will also introduce officially built artifacts for OSX (.dmg) and Linux (.zip).

The Travis jobs are setup in two stages.
1. test - The default stage that runs the linting and tests.
2. publish - This stage only run for tag builds. Makes the project and publishes it to a GitHub release.
Each stage has a separate job for each of the platforms: Windows, OSX, and Linux.  The publish stage will only run if all of the jobs in the test stage have completed successfully. 

![screenshot-8](https://user-images.githubusercontent.com/8441903/61557654-72a0cd00-aa2a-11e9-8028-b39be594d3cb.png)

I have also moved the Electron Forge configuration out of the package.json and into a new forge.config.js file.  This allows us to have a postMake hook that will rename the artifacts generated by the make so that we can have consistent naming. After all of the Travis jobs complete for a tag, a draft GitHub release like this one will be created:

![screenshot-9](https://user-images.githubusercontent.com/8441903/61557817-d7f4be00-aa2a-11e9-8f98-78bda5bdfe14.png)

Closes #4 