### PR TITLE
fix(app): Use new save dialog API

### DIFF
--- a/src/cucumberForgeDesktop.js
+++ b/src/cucumberForgeDesktop.js
@@ -84,7 +84,7 @@ const saveOutput = () => {
   remote.dialog.showSaveDialog({
     title: 'Save Report',
     defaultPath: defPath,
-  }, writeReportHTMLToFile);
+  }).then((result) => writeReportHTMLToFile(result.filePath));
 };
 
 const setNewFolderPath = (folderPath) => {


### PR DESCRIPTION
The recent update of the Electron version (6.0.1 > 7.1.10) broke the save-dialog functionality because the Electron API changed.  

This change fixes the issue by consuming the new API as described [here](https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options).