### PR TITLE
feat(Auto-Update): Display version readme text in popup message

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
   <body id="appBody" class="empty">
     <div id="mask"></div>
     <nav class="navbar navbar-dark bg-primary fixed-top">
-      <a class="navbar-brand" href="https://github.com/cerner/cucumber-forge-desktop/issues" target="_blank" rel="noopener">
+      <a class="navbar-brand" href="https://github.com/cerner/cucumber-forge-desktop" target="_blank" rel="noopener">
         <img src="./resources/png/CucumberForge_48.png" width="30" height="30" class="d-inline-block align-top" alt="">
         Cucumber Forge
       </a>

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ const checkForUpdates = () => {
       type: 'info',
       buttons: ['Update', 'Later'],
       title: 'Cucumber Forge Update',
-      message: meta.version,
+      message: `A new version of Cucumber Forge is available! ${meta.version}`,
       detail: meta.readme,
     };
     const response = dialog.showMessageBoxSync(dialogOpts);

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const checkForUpdates = () => {
       buttons: ['Update', 'Later'],
       title: 'Cucumber Forge Update',
       message: meta.version,
-      detail: 'A new version of Cucumber Forge is available.',
+      detail: meta.readme,
     };
     const response = dialog.showMessageBoxSync(dialogOpts);
     if (response === 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ const checkForUpdates = () => {
       type: 'info',
       buttons: ['Update', 'Later'],
       title: 'Cucumber Forge Update',
-      message: `A new version of Cucumber Forge is available! ${meta.version}`,
+      message: 'A new version of Cucumber Forge is available!',
       detail: meta.readme,
     };
     const response = dialog.showMessageBoxSync(dialogOpts);


### PR DESCRIPTION
Updates the popup message that is shown when there is a new update to display the readme text from the updates.json file in the popup window.

This will provide the flexibility for displaying more information about the update. The popup detail space supports multi-line strings

Closes https://github.com/cerner/cucumber-forge-desktop/issues/45