### PR TITLE
Roll back electron forge version to 52

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
     "popper.js": "^1.16.1"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^6.0.0-beta.53",
-    "@electron-forge/maker-dmg": "^6.0.0-beta.53",
-    "@electron-forge/maker-squirrel": "^6.0.0-beta.53",
-    "@electron-forge/maker-zip": "^6.0.0-beta.53",
-    "@electron-forge/publisher-github": "^6.0.0-beta.53",
+    "@electron-forge/cli": "^6.0.0-beta.52",
+    "@electron-forge/maker-dmg": "^6.0.0-beta.52",
+    "@electron-forge/maker-squirrel": "^6.0.0-beta.52",
+    "@electron-forge/maker-zip": "^6.0.0-beta.52",
+    "@electron-forge/publisher-github": "^6.0.0-beta.52",
     "await-timeout": "^1.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Need to back this version up due to this defect https://github.com/electron-userland/electron-forge/issues/1958 that is preventing our release process from deploying to GitHub.
