### PR TITLE
Move dark mode toggle box to app setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out
+.idea

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,9 @@ Cerner Corporation
 - Joshua Kuestersteffen [@jkuester]
 - Matej Voboril [@tobitenno]
 - Eric Swanson [@es20641]
+- Khoa Le [@lendkhoa]
 
 [@jkuester]: https://github.com/jkuester
 [@tobitenno]: https://github.com/tobitenno
 [@es20641]: https://github.com/es20641
+[@lendkhoa]:https://github.com/lendkhoa

--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,7 +1187,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assertion-error-formatter": {
@@ -1366,7 +1366,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -1514,7 +1514,7 @@
     "chai-as-promised": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
         "check-error": "^1.0.2"
@@ -1597,7 +1597,7 @@
     "cli-table3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha1-AlI3LZTfxA29jfBgBfSPMfZW8gI=",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
         "colors": "^1.1.2",
@@ -1620,7 +1620,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -2040,6 +2040,11 @@
         "type": "^1.0.1"
       }
     },
+    "darkmode-js": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/darkmode-js/-/darkmode-js-1.5.7.tgz",
+      "integrity": "sha512-gM1KhV/yy/84ZUpES9/oeOn0CVtuOi2HBd+Kccr4CJz+rFccQo2gUuPbjfyPXUx7t800Zf408G6kZb5rkTgjFA=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2067,7 +2072,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2090,7 +2095,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -2271,9 +2276,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.58",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.58.tgz",
-          "integrity": "sha512-Be46CNIHWAagEfINOjmriSxuv7IVcqbGe+sDSg2SYCEz/0CRBy7LRASGfRbD8KZkqoePU73Wsx3UvOSFcq/9hA==",
+          "version": "12.19.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.3.tgz",
+          "integrity": "sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg==",
           "dev": true
         },
         "extract-zip": {
@@ -3648,7 +3653,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4700,7 +4705,10 @@
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
       "integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "nan": "^2.4.0"
+      }
     },
     "macos-release": {
       "version": "2.4.1",
@@ -4908,7 +4916,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -4990,13 +4998,20 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5024,7 +5039,7 @@
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
@@ -5554,7 +5569,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -6332,7 +6347,7 @@
     "stack-chain": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
-      "integrity": "sha1-1z0Rcq+JVl8HQ4tbzAhoMbZomy0=",
+      "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
       "dev": true
     },
     "stack-generator": {
@@ -6411,7 +6426,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -6716,7 +6731,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -6884,7 +6899,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bootstrap": "^4.5.2",
     "bootswatch": "^4.5.2",
     "cucumber-forge-report-generator": "^1.3.0",
+    "darkmode-js": "^1.5.7",
     "electron-log": "^4.2.4",
     "electron-simple-updater": "^2.0.9",
     "electron-squirrel-startup": "^1.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -28,6 +28,7 @@
       #appSettings {
         color: #f1f1f1;
         display: none;
+        isolation: isolate;
       }
       #appSettings hr {
         color: #f1f1f1;
@@ -75,7 +76,7 @@
         </div>
       </form>
     </nav>
-    <div id="appSettings">
+    <div class="darkmode-ignore" id="appSettings">
       <div class="container">
         <h1>Settings</h1>
         <hr>

--- a/src/index.html
+++ b/src/index.html
@@ -26,9 +26,10 @@
         z-index:9999;
       }
       #appSettings {
+        isolation: isolate !important;
+        mix-blend-mode: difference;
         color: #f1f1f1;
         display: none;
-        isolation: isolate;
       }
       #appSettings hr {
         color: #f1f1f1;
@@ -76,7 +77,7 @@
         </div>
       </form>
     </nav>
-    <div class="darkmode-ignore" id="appSettings">
+    <div id="appSettings">
       <div class="container">
         <h1>Settings</h1>
         <hr>
@@ -84,6 +85,8 @@
           <div class="form-group">
             <label for="dialectSelection">Default Gherkin Dialect:</label>
             <select id="dialectSelection" class="form-control" onchange="changeGherkinDialect()">
+              <br/>
+            <input type="checkbox" id="darkMode"><label for="darkMode"> Dark Mode </label>
               <!-- Options are added programmatically -->
             </select>
           </div>

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,11 @@ const { remote, ipcRenderer } = require('electron');
 const Store = require('electron-store');
 const Generator = require('cucumber-forge-report-generator');
 
+const DarkMode = require('darkmode-js');
+
+let darkMode = null;
+let darkModeCheckBox = null;
+
 const store = new Store();
 const fileEncoding = 'utf-8';
 
@@ -12,6 +17,23 @@ let selectedFolderPath;
 let projectName;
 let reportHTML;
 let tag;
+
+const initDarkMode = () => {
+  darkModeCheckBox = document.getElementById('darkMode');
+  if (darkModeCheckBox) {
+    darkModeCheckBox.addEventListener('click', () => {
+      if (!darkMode) {
+        darkMode = new DarkMode();
+        darkMode.toggle();
+      } else {
+        darkMode.toggle();
+      }
+    });
+  }
+  if (darkMode && darkMode.isActivated()) {
+    darkMode.toggle();
+  }
+};
 
 const toggleLoadingInd = () => {
   if (reportHTML) {
@@ -30,11 +52,12 @@ const toggleLoadingInd = () => {
 
 const toggleSettingsVisibility = () => {
   const settingsDiv = document.getElementById('appSettings');
+  const appBody = document.getElementById('appBody');
   if (!settingsDiv.style.display || settingsDiv.style.display === 'none') {
     // Settings are currently hidden. Un-hide them.
     if (reportHTML) {
       // If there is a report, hide it.
-      document.getElementById('appBody').classList.add('empty');
+      appBody.classList.add('empty');
       document.getElementById('output').style.display = 'none';
     }
     settingsDiv.style.display = 'block';
@@ -43,9 +66,18 @@ const toggleSettingsVisibility = () => {
     settingsDiv.style.display = 'none';
     if (reportHTML) {
       // If there is a report, un-hide it.
-      document.getElementById('appBody').classList.remove('empty');
+      appBody.classList.remove('empty');
       document.getElementById('output').style.display = 'block';
     }
+  }
+
+  if (darkMode && !darkMode.isActivated()) {
+    const darkModeReady = document.getElementsByClassName('darkmode-background');
+    if (darkModeReady.length > 0) {
+      settingsDiv.style.color = '#222222';
+    }
+  } else if (darkMode && darkMode.isActivated()) {
+    settingsDiv.style.color = '#f1f1f1';
   }
 };
 
@@ -58,6 +90,7 @@ ipcRenderer.on('create-report-reply', (event, arg) => {
 
   toggleLoadingInd();
   document.getElementById('output').innerHTML = reportHTML;
+  initDarkMode();
   init(); // eslint-disable-line no-undef
 });
 

--- a/src/render.js
+++ b/src/render.js
@@ -20,19 +20,14 @@ let tag;
 
 const initDarkMode = () => {
   darkModeCheckBox = document.getElementById('darkMode');
-  if (darkModeCheckBox) {
-    darkModeCheckBox.addEventListener('click', () => {
-      if (!darkMode) {
-        darkMode = new DarkMode();
-        darkMode.toggle();
-      } else {
-        darkMode.toggle();
-      }
-    });
-  }
-  if (darkMode && darkMode.isActivated()) {
+  const options = {
+    saveInCookies: false, // default: true,
+    autoMatchOsTheme: true, // default: true
+  };
+  darkMode = new DarkMode(options);
+  darkModeCheckBox.addEventListener('click', () => {
     darkMode.toggle();
-  }
+  });
 };
 
 const toggleLoadingInd = () => {
@@ -70,15 +65,6 @@ const toggleSettingsVisibility = () => {
       document.getElementById('output').style.display = 'block';
     }
   }
-
-  if (darkMode && !darkMode.isActivated()) {
-    const darkModeReady = document.getElementsByClassName('darkmode-background');
-    if (darkModeReady.length > 0) {
-      settingsDiv.style.color = '#222222';
-    }
-  } else if (darkMode && darkMode.isActivated()) {
-    settingsDiv.style.color = '#f1f1f1';
-  }
 };
 
 ipcRenderer.on('create-report-reply', (event, arg) => {
@@ -90,7 +76,6 @@ ipcRenderer.on('create-report-reply', (event, arg) => {
 
   toggleLoadingInd();
   document.getElementById('output').innerHTML = reportHTML;
-  initDarkMode();
   init(); // eslint-disable-line no-undef
 });
 
@@ -185,4 +170,5 @@ const initSettings = () => {
   document.getElementById('appVersion').innerHTML = `Version: ${remote.app.getVersion()}`;
 };
 
+initDarkMode();
 initSettings();


### PR DESCRIPTION
### Summary
Move the dark-mode toggle box to the app setting instead of individual view setting in response to this [conversation](https://github.com/cerner/cucumber-forge-report-generator/pull/63#issuecomment-743269544)
![dark_mode_fix_location2](https://user-images.githubusercontent.com/13859409/102411232-3a9f1000-3fb7-11eb-8219-fa3dc1beaf47.gif)

Due to the default option of [darkmodejs](https://github.com/sandoche/Darkmode.js) background color is white (#fff). and the need to instantiate the Darkmode class variable independently from appSetting section to avoid unwanted side effect (shown below - output's content is not visible due to our old similar background color), the app's default background is now also white. I have tried many different ways to get around this it seems unlikely. Does anyone have any suggestions?
![dark_mode_color_issue2](https://user-images.githubusercontent.com/13859409/102411248-412d8780-3fb7-11eb-8ee6-b9fd85d02515.gif)


