### PR TITLE
fix: force an extension when tags are provided

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -96,9 +96,9 @@ const createReportForFolder = (folderPath) => {
 };
 
 const getDefaultOutputFileName = () => {
-  let reportName = `${projectName}.htm`;
+  let reportName = `${projectName}.html`;
   if (tag) {
-    reportName = `${tag}_${reportName}.htm`;
+    reportName = `${tag}_${reportName}.html`;
   }
   return reportName;
 };

--- a/src/render.js
+++ b/src/render.js
@@ -96,9 +96,9 @@ const createReportForFolder = (folderPath) => {
 };
 
 const getDefaultOutputFileName = () => {
-  let reportName = `${projectName}.html`;
+  let reportName = `${projectName}.htm`;
   if (tag) {
-    reportName = `${tag}_${reportName}`;
+    reportName = `${tag}_${reportName}.htm`;
   }
   return reportName;
 };


### PR DESCRIPTION
### Summary
Default an extension on tagged filenames when saving

### Additional Details
closes #64